### PR TITLE
Un-mix trap and exception in {m,s}epc

### DIFF
--- a/src/machine.tex
+++ b/src/machine.tex
@@ -1723,8 +1723,9 @@ addresses.  Implementations may convert some invalid address patterns into
 other invalid addresses prior to writing them to {\tt mepc}.
 
 When a trap is taken into M-mode, {\tt mepc} is written with the virtual
-address of the instruction that encountered the exception.  Otherwise,
-{\tt mepc} is never written by the implementation, though it may be
+address of the instruction that encountered the exception or the virtual
+address of the next instruction to be executed in the interrupted context.
+Otherwise, {\tt mepc} is never written by the implementation, though it may be
 explicitly written by software.
 
 \begin{figure}[h!]

--- a/src/supervisor.tex
+++ b/src/supervisor.tex
@@ -558,8 +558,9 @@ addresses.  Implementations may convert some invalid address patterns into
 other invalid addresses prior to writing them to {\tt sepc}.
 
 When a trap is taken into S-mode, {\tt sepc} is written with the virtual
-address of the instruction that encountered the exception.  Otherwise,
-{\tt sepc} is never written by the implementation, though it may be
+address of the instruction that encountered the exception or the virtual
+address of the next instruction to be executed in the interrupted context.
+Otherwise, {\tt sepc} is never written by the implementation, though it may be
 explicitly written by software.
 
 \begin{figure}[h!]


### PR DESCRIPTION
This might be a bit pedantic, but the current wording in the spec mixes
up traps and execptions here in a way that makes it sound like
interrupts don't write {m,s}epc if you're reading quickly.

I don't really like the wording I've proposed, so this is more of a bug
report than a fix.